### PR TITLE
RFC: add initial minimal viable product RFC

### DIFF
--- a/rfcs/RFC-0002.md
+++ b/rfcs/RFC-0002.md
@@ -2,12 +2,12 @@
 
 | Information                 | Details                          |
 |-----------------------------|----------------------------------|
-| RFC document number         | RFC 0000 (to be assigned)        |
+| RFC document number         | RFC 0002                         |
 | Feature name                | `initial_minimal_viable_product` |
 | Start date                  | 2020-09-28                       |
 | Implementation Pull Request | N/A                              |
 | Tracking Issue              | N/A                              |
-| Status                      | **Pending**                      |
+| Status                      | **Accepted**                     |
 | Related RFCs                | N/A                              |
 
 ## Summary

--- a/rfcs/RFC-0002.md
+++ b/rfcs/RFC-0002.md
@@ -1,4 +1,4 @@
-# RFC 0000: Initial Minimal Viable Product
+# RFC 0002: Initial Minimal Viable Product
 
 | Information                 | Details                          |
 |-----------------------------|----------------------------------|

--- a/rfcs/RFC-0002.md
+++ b/rfcs/RFC-0002.md
@@ -1,0 +1,187 @@
+# RFC 0000: Initial Minimal Viable Product
+
+| Information                 | Details                          |
+|-----------------------------|----------------------------------|
+| RFC document number         | RFC 0000 (to be assigned)        |
+| Feature name                | `initial_minimal_viable_product` |
+| Start date                  | 2020-09-28                       |
+| Implementation Pull Request | N/A                              |
+| Tracking Issue              | N/A                              |
+| Status                      | **Pending**                      |
+| Related RFCs                | N/A                              |
+
+## Summary
+
+We introduce the set of features planned for the Initial Minimal Viable Product
+(I-MVP) for the **UCL Hub** application.
+
+## Motivation
+
+We need to pin down a small set of features so that these features, considered
+critically important for our purposes, can be feasibly implemented by a small
+team of developers towards the middle or end of January.
+
+## Guide-level Explanation
+
+### Guiding Principles
+
+**UCL Hub** is an *open-source*, *not-for-profit* student assistant and student
+community application.
+
+We wish to:
+
+1. improve the **accessibility** of UCL and UCL-related information for UCL
+   students;
+2. help build a *welcoming and inclusive community* among UCL students.
+
+### Target Audience
+
+Our target audience is **UCL students**, including those who are currently
+enrolled as well as offer-holders (collectively, UCL students).
+
+These students may want to *discuss* and *share information* among fellow
+students w.r.t. to topics such as:
+
+- Second-hand item trading (place for information, but not a "market")
+- Housing (residence)
+- Questions and Answers (Q&A)
+- Recommended resources and notes
+- Career advice or information
+- Lost & Found
+- Course discussion
+- Meme sharing
+- General (photo, info, opportunity) sharing
+- Societies and clubs (society pages, membership cards, events, discussions)
+
+They may also wish to receive *personalized assistance and curated information*
+such as:
+
+- Have easy access to their timetables (personal, course)
+- Transition Mentor style advice (especially for offer holder and new students)
+- Check library and study space status (number of occupied seats, opening
+  times)
+   - We can link to UCL library's booking service (no available API)
+- Check empty lecture rooms based on time (e.g. next hour availability, see
+  UCL Assistant)
+- Restaurants and cafe around the campus (possibly in the vicinity of the
+  campus as well)
+- Professor and staff info look up (email address, dept, name)
+- Link to commonly used UCL services
+- Current COVID-19 situation (guidelines, restrictions, clusters, pandemic
+  severeness, vaccine development status)
+- TfL status (tube line status, buses router - maybe in the end)
+
+## Reference-level Explanation
+
+There's a *lot* of potentially desired features, but given the small team size
+and timeframe, we need to reduce the possible requirements down to a core set
+that delivers the most value for UCL students. The selection and prioritization
+of these features were conducted through a meeting by design team members
+[1].
+
+As such, we designate two sets of **core functional requirements**:
+
+1. **Personalized Information and Guidance**.
+2. **Student Community Facilities**.
+   - To ensure *constructive* and *inclusive* community-building, it is
+     inevitable that we also require first-class community moderation tooling.
+
+To align with our guiding principles, we also designate two sets of
+**core non-functional requirements**:
+
+1. **Accessibility**.
+2. **Privacy and Safety**.
+
+The two non-functional requirements will also help us address security issues,
+such as securing personal information, as well as legal issues, such as to
+comply with regulations and laws such as the GDPR by only giving personal
+information to authorized parties when the user explicitly consents
+(vis-a-vis opt-in personal information sharing).
+
+### Core Functional Requirements
+
+#### Personalized Information and Guidance
+
+1. Personal timetable
+    1. Daily view
+    2. Weekly view
+    3. Monthly view
+2. Library and study space availability
+    1. Absolute number of seats available
+    2. Percentage of seats available
+    3. Sorting (by name, available seats)
+    4. User favourite libraries
+3. COVID-19 information
+    1. Daily, weekly and monthly change in number of cases (infected, deaths,
+       recovered, suspected/quarantined)
+    2. Daily, weekly and monthly change in total number of cases
+    3. Nearby cases
+    4. Trends by different date intervals
+    5. Protection information (UK government-issued guidance + China
+4. Transport for London (TfL) tube status
+       government-issued guidance + UCL guidance)
+
+#### Student Community Facilities
+
+1. General Forum
+    1. Publish posts with text, images and links
+        1. Allow comments
+    2. Separate multiple locales (initially zh, en)
+    3. Post category
+    4. View a list of posts
+    5. Filter by category, sort by publish date
+2. Second-hand Market (**not** C2C/B2C, *only* to allow information exchange,
+   we do not handle transactions)
+    1. Filter by item type, publish date, price range
+3. User Profile Management and Display
+    1. Select info to display
+    2. User profile information (selective visibility):
+        1. First name, middle name and last name (optional)
+        2. Programme
+        3. Education level
+        4. Year of study
+        5. Profile picture
+        6. Email
+        7. Social media links (facebook, twitter, instagram, github for now)
+        8. Phone number
+    3. Contact details
+    4. Verified UCL student status (via UCL API)
+
+## Drawbacks
+
+- Some features are sacrificed to make the workload feasible for the Intial
+  MVP.
+
+## Scope and Effort
+
+It is expected that these features be designed, implemented, tested and
+evaluated towards the middle or end of January to the level of completenesss
+that would be expected for a Public Beta.
+
+## Prior Art
+
+- UCL Assistant
+- UCL Go
+- UCLCSSA WeChat Miniapp
+
+## Unresolved Questions
+
+- How do we gather and analyze user feedback to improve the design?
+
+## Future Possibilities
+
+Possible desired features by users that were not included in the Initial
+MVP was also listed in the Target Audience section; also see [1] for more
+ideas.
+
+## Reference
+
+1. @UCLHub/design, “Basic Concepts, Guiding Principles and Initial MVP
+   Meeting,” *UCL Hub Meeting Minutes Repository*, 21-Sep-2020. [Online].
+   Available:
+   <https://github.com/UCLHub/meeting-minutes/blob/master/design/2020-09-24.md>.
+   [Accessed: 28-Sep-2020].
+
+## Addendum
+
+None.

--- a/rfcs/RFC-0002.md
+++ b/rfcs/RFC-0002.md
@@ -31,7 +31,7 @@ community application.
 We wish to:
 
 1. improve the **accessibility** of UCL and UCL-related information for UCL
-   students;
+   students; and
 2. help build a *welcoming and inclusive community* among UCL students.
 
 ### Target Audience


### PR DESCRIPTION
This PR adds the RFC for the Initial Minimal Viable Product, as discussed in the Design Team meeting minutes (available at: https://github.com/UCLHub/meeting-minutes/blob/master/design/2020-09-24.md).

Please carefully review the proposed RFC @UCLHub/design team members.

Closes #4.